### PR TITLE
Update resources.Rmd to fix typo

### DIFF
--- a/resources.Rmd
+++ b/resources.Rmd
@@ -19,7 +19,7 @@ There are many resources online and in print. This is by no means a comprehensiv
 - [Using purrr](2019_lesson_purrr_tutorial.html)
 - [Mapping in R](https://ryanpeek.github.io/mapping-in-R-workshop/)
 - [Text Mining](2019_lesson_text_mining_mlk.html)
-- [Github Collaboration with Branches](/2019_lesson_github_collaboration.html)
+- [Github Collaboration with Branches](2019_lesson_github_collaboration.html)
 - [Data Carpentry: R and SQL](http://www.datacarpentry.org/R-ecology-lesson/05-r-and-databases.html)
 - [Longer Iteration Lesson](2019_lesson_iteration.html)
 


### PR DESCRIPTION
This is a minor fix to hopefully help the github_collaboration page get built. Just a leading `/` which I think was causing the page not to get built/be found. Currently [this page](https://gge-ucd.github.io/2019_lesson_github_collaboration.html) doesn't work: 

Someone will need to rebuild and push site up. Thanks!